### PR TITLE
Configure Travis CI for the serializer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ node_js:
   - 9
 
 before_install:
-  # Install tsc, type TypeScript compiler.
+  # Install tsc, the TypeScript compiler.
   - npm install -g typescript
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: node_js
+
+# The following is a list of all versions of node we will test
+# the closure serializer on.
+node_js:
+  # Latest stable version of node.
+  - node
+  # Node v10.9.0 (same as GitLab CI config).
+  - 10.9.0
+
+before_install:
+  # Install tsc, type TypeScript compiler.
+  - npm install -g typescript
+
+install:
+  # Install NPM packages.
+  - pushd serialize-closures; npm install; popd
+  - pushd ts-closure-transform; npm install; popd
+
+script:
+  # Build projects.
+  - pushd serialize-closures; tsc; popd
+  - pushd ts-closure-transform; tsc; popd
+  # Run the tests.
+  - pushd serialize-closures; npm test; popd
+  - pushd ts-closure-transform; npm test; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ node_js:
   - node
   # Node v10.9.0 (same as GitLab CI config).
   - 10.9.0
+  # Node v9 as some node APIs that we rely on behave differently on Node <10.
+  # See comments in serialize-closures/src/{builtins,serializedGraph}.ts.
+  - 9
 
 before_install:
   # Install tsc, type TypeScript compiler.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![npm version](https://badge.fury.io/js/serialize-closures.svg)](https://badge.fury.io/js/serialize-closures)
 [![npm version](https://badge.fury.io/js/ts-closure-transform.svg)](https://badge.fury.io/js/ts-closure-transform)
+[![Build Status](https://travis-ci.org/nokia/ts-serialize-closures.svg?branch=master)](https://travis-ci.org/nokia/ts-serialize-closures)
 
 # ts-serialize-closures
 


### PR DESCRIPTION
Hi! This PR proposes adding a Travis CI configuration to the serializer repo.

Travis CI automatically builds and tests any pull requests and commits, free of charge for public repos. Travis' results show up as status checks in pull requests, which makes them easier to review in my opinion.

If you're interested in these changes, you'll want to enable Travis CI for this repository in addition to merging this PR. Enabling Travis CI can be done fairly easily on https://travis-ci.org.

With regard to the specific configuration I've created: I made Travis test the serializer on the latest version of node, on v10.9.0 (same as the GitLab CI configuration), and on v9 (in accordance with comments in `serialize-closures/src/{builtins,serializedGraph}.ts`). Other than that, the Travis CI configuration behaves identically to the old GitLab CI configuration.