### PR TITLE
Broader and more accurate JavaScript syntax support

### DIFF
--- a/ts-closure-transform/compile.ts
+++ b/ts-closure-transform/compile.ts
@@ -34,6 +34,7 @@ export const CJS_CONFIG = {
   noUnusedLocals: true,
   noUnusedParameters: true,
   stripInternal: true,
+  noImplicitUseStrict: true,
   target: ts.ScriptTarget.ES5
 };
 
@@ -61,9 +62,13 @@ export default function compile(
     let allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
 
     allDiagnostics.forEach(diagnostic => {
-      let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
       let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-      console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
+      if (diagnostic.file) {
+        let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
+      } else {
+        console.log(`${message}`);
+      }
     });
   }
 

--- a/ts-closure-transform/compile.ts
+++ b/ts-closure-transform/compile.ts
@@ -41,7 +41,8 @@ export default function compile(
   input: string,
   options: ts.CompilerOptions = CJS_CONFIG,
   writeFile?: ts.WriteFileCallback,
-  printDiagnostics: boolean = true) {
+  printDiagnostics: boolean = true,
+  transformClosures: boolean = true) {
 
   const files = globSync(input);
 
@@ -50,14 +51,11 @@ export default function compile(
 
   const msgs = {};
 
-  let emitResult = program.emit(undefined, writeFile, undefined, undefined, {
-    before: [
-      beforeTransform()
-    ],
-    after: [
-      afterTransform()
-    ]
-  });
+  let transformers = transformClosures
+    ? { before: [beforeTransform()], after: [afterTransform()] }
+    : undefined;
+
+  let emitResult = program.emit(undefined, writeFile, undefined, undefined, transformers);
 
   if (printDiagnostics) {
     let allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);

--- a/ts-closure-transform/compile.ts
+++ b/ts-closure-transform/compile.ts
@@ -40,7 +40,8 @@ export const CJS_CONFIG = {
 export default function compile(
   input: string,
   options: ts.CompilerOptions = CJS_CONFIG,
-  writeFile?: ts.WriteFileCallback) {
+  writeFile?: ts.WriteFileCallback,
+  printDiagnostics: boolean = true) {
 
   const files = globSync(input);
 
@@ -58,12 +59,15 @@ export default function compile(
     ]
   });
 
-  let allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+  if (printDiagnostics) {
+    let allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
 
-  allDiagnostics.forEach(diagnostic => {
-    let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
-    let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-    console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
-  });
+    allDiagnostics.forEach(diagnostic => {
+      let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+      let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+      console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
+    });
+  }
+
   return msgs;
 }

--- a/ts-closure-transform/src/box-mutable-captured-vars.ts
+++ b/ts-closure-transform/src/box-mutable-captured-vars.ts
@@ -33,10 +33,10 @@ import { VariableVisitor, VariableId, VariableNumberingScope, VariableNumberingS
 /**
  * A variable visitor that tracks down mutable shared variables.
  */
-class MutableSharedVariableFinder extends VariableVisitor {
+export class MutableSharedVariableFinder extends VariableVisitor {
   private readonly updateCounts: { [id: number]: number };
   private readonly defScopes: { [id: number]: VariableNumberingScope };
-  private readonly sharedVariables: VariableId[];
+  private readonly sharedVars: VariableId[];
 
   /**
    * Creates a mutable shared variable finder.
@@ -46,7 +46,14 @@ class MutableSharedVariableFinder extends VariableVisitor {
     super(ctx);
     this.updateCounts = {};
     this.defScopes = {};
-    this.sharedVariables = [];
+    this.sharedVars = [];
+  }
+
+  /**
+   * Gets a list of all shared variables detected by this variable visitor.
+   */
+  get sharedVariables(): ReadonlyArray<VariableId> {
+    return this.sharedVars;
   }
 
   /**
@@ -54,7 +61,7 @@ class MutableSharedVariableFinder extends VariableVisitor {
    */
   get mutableSharedVariables(): ReadonlyArray<VariableId> {
     let results = [];
-    for (let id of this.sharedVariables) {
+    for (let id of this.sharedVars) {
       if (this.updateCounts[id] > 1) {
         results.push(id);
       }
@@ -88,8 +95,8 @@ class MutableSharedVariableFinder extends VariableVisitor {
 
   private noteAppearance(id: VariableId) {
     if (id in this.defScopes && this.defScopes[id] !== this.scope.functionScope) {
-      if (this.sharedVariables.indexOf(id) < 0) {
-        this.sharedVariables.push(id);
+      if (this.sharedVars.indexOf(id) < 0) {
+        this.sharedVars.push(id);
       }
     }
   }

--- a/ts-closure-transform/src/variable-visitor.ts
+++ b/ts-closure-transform/src/variable-visitor.ts
@@ -64,17 +64,17 @@ export class VariableNumberingScope {
   private readonly localVariables: { [name: string]: VariableId };
 
   /**
-   * This scope's parent scope.
-   */
-  private readonly parent: VariableNumberingScope | undefined;
-
-  /**
    * A set of variable IDs that have not been explicitly defined
    * in a variable numbering scope yet. This set is shared by
    * all variable numbering scopes and can be indexed by variable
    * names.
    */
   private readonly pendingVariables: { [name: string]: VariableId };
+
+  /**
+   * This scope's parent scope.
+   */
+  readonly parent: VariableNumberingScope | undefined;
 
   /**
    * The variable numbering store for this scope.
@@ -535,7 +535,7 @@ export abstract class VariableVisitor {
                 expression.operand,
                 value)));
         } else {
-          let temp = this.createTempVariable();
+          let temp = this.createTemporary();
           this.ctx.hoistVariableDeclaration(temp);
 
           let firstUse = this.visitUse(expression.operand, id);
@@ -618,7 +618,7 @@ export abstract class VariableVisitor {
         let init = this.visitDef(name, id);
         let rewrite = this.visitAssignment(name, id);
         if (rewrite) {
-          let temp = this.createTempVariable();
+          let temp = this.createTemporary();
           fixups.push(
             ts.createVariableStatement(
               [],
@@ -859,7 +859,7 @@ export abstract class VariableVisitor {
   /**
    * Creates a temporary variable name.
    */
-  private createTempVariable(): ts.Identifier {
+  protected createTemporary(): ts.Identifier {
     let result = ts.createTempVariable(undefined);
     this.scope.define(result);
     return result;

--- a/ts-closure-transform/src/variable-visitor.ts
+++ b/ts-closure-transform/src/variable-visitor.ts
@@ -133,6 +133,28 @@ export class VariableNumberingScope {
   }
 
   /**
+   * Defines in this scope all variables specified by a binding name.
+   * @param name A binding name that lists variables to define.
+   */
+  defineVariables(name: ts.BindingName) {
+    if (name === undefined) {
+
+    } else if (ts.isIdentifier(name)) {
+      this.define(name);
+    } else if (ts.isArrayBindingPattern(name)) {
+      for (let elem of name.elements) {
+        if (ts.isBindingElement(elem)) {
+          this.defineVariables(elem.name);
+        }
+      }
+    } else {
+      for (let elem of name.elements) {
+        this.defineVariables(elem.name);
+      }
+    }
+  }
+
+  /**
    * Gets the identifier for a variable with a
    * particular name in the current scope.
    * @param name The name of the variable.
@@ -542,23 +564,12 @@ export abstract class VariableVisitor {
   /**
    * Defines all variables in a binding name.
    * @param name A binding name.
+   * @param scope The scope to define the variables in.
    */
   private defineVariables(name: ts.BindingName) {
-    if (name === undefined) {
-
-    } else if (ts.isIdentifier(name)) {
-      this.scope.define(name);
-    } else if (ts.isArrayBindingPattern(name)) {
-      for (let elem of name.elements) {
-        if (ts.isBindingElement(elem)) {
-          this.defineVariables(elem.name);
-        }
-      }
-    } else {
-      for (let elem of name.elements) {
-        this.defineVariables(elem.name);
-      }
-    }
+    // This is a little off for 'let' bindings, but we'll just
+    // assume that those have all been lowered to 'var' already.
+    this.scope.functionScope.defineVariables(name);
   }
 
   /**

--- a/ts-closure-transform/src/variable-visitor.ts
+++ b/ts-closure-transform/src/variable-visitor.ts
@@ -242,13 +242,29 @@ export abstract class VariableVisitor {
     }
     // Expressions
     else if (ts.isIdentifier(node)) {
-      return this.visitUse(node, this.scope.getId(node));
+      if (node.text !== "undefined"
+        && node.text !== "null"
+        && node.text !== "arguments") {
+        return this.visitUse(node, this.scope.getId(node));
+      } else {
+        return node;
+      }
+
+    } else if (ts.isTypeNode(node)) {
+      // Don't visit type nodes.
+      return node;
 
     } else if (ts.isPropertyAccessExpression(node)) {
       return ts.updatePropertyAccess(
         node,
         this.visitExpression(node.expression),
         node.name);
+
+    } else if (ts.isQualifiedName(node)) {
+      return ts.updateQualifiedName(
+        node,
+        <ts.EntityName>this.visit(node.left),
+        node.right);
 
     } else if (ts.isPropertyAssignment(node)) {
       return ts.updatePropertyAssignment(

--- a/ts-closure-transform/src/variable-visitor.ts
+++ b/ts-closure-transform/src/variable-visitor.ts
@@ -380,6 +380,38 @@ export abstract class VariableVisitor {
         node.type,
         body);
 
+    } else if (ts.isGetAccessor(node)) {
+      return ts.updateGetAccessor(
+        node,
+        node.decorators,
+        node.modifiers,
+        node.name,
+        node.parameters,
+        node.type,
+        this.visitFunctionBody(node.parameters, node.body));
+
+    } else if (ts.isSetAccessor(node)) {
+      return ts.updateSetAccessor(
+        node,
+        node.decorators,
+        node.modifiers,
+        node.name,
+        node.parameters,
+        this.visitFunctionBody(node.parameters, node.body));
+
+    } else if (ts.isMethodDeclaration(node)) {
+      return ts.updateMethod(
+        node,
+        node.decorators,
+        node.modifiers,
+        node.asteriskToken,
+        node.name,
+        node.questionToken,
+        node.typeParameters,
+        node.parameters,
+        node.type,
+        this.visitFunctionBody(node.parameters, node.body));
+
     } else if (ts.isFunctionDeclaration(node)) {
       return this.visitFunctionDeclaration(node);
 

--- a/ts-closure-transform/test/fixture/for-in.out.js
+++ b/ts-closure-transform/test/fixture/for-in.out.js
@@ -1,0 +1,15 @@
+var _a;
+let x = { value: undefined };
+x.value = 10;
+let obj = { y: 42 };
+(_a = function () {
+    var _a;
+    for (let x in obj) {
+        let f = (_a = () => console.log(x), _a.__closure = () => ({ console, x }), _a);
+        f();
+    }
+}, _a.__closure = () => ({ obj, console }), _a)();
+function g() {
+    ++x.value;
+}
+g.__closure = () => ({ x });

--- a/ts-closure-transform/test/fixture/for-in.ts
+++ b/ts-closure-transform/test/fixture/for-in.ts
@@ -1,0 +1,11 @@
+let x = 10;
+let obj = { y: 42 };
+(function() {
+    for (let x in obj) {
+        let f = () => console.log(x);
+        f();
+    }
+})();
+function g() {
+    x++;
+}

--- a/ts-closure-transform/test/fixture/function-assignment.out.js
+++ b/ts-closure-transform/test/fixture/function-assignment.out.js
@@ -1,0 +1,13 @@
+var f = { value: undefined };
+f.value = function () {
+    return 2;
+};
+function g() {
+    f.value = () => 4;
+    return;
+}
+g.__closure = () => ({ f });
+function h() {
+    return f.value();
+}
+h.__closure = () => ({ f });

--- a/ts-closure-transform/test/fixture/function-assignment.ts
+++ b/ts-closure-transform/test/fixture/function-assignment.ts
@@ -1,0 +1,12 @@
+function f() {
+    return 2;
+}
+
+function g() {
+    f = () => 4;
+    return;
+}
+
+function h() {
+    return f();
+}

--- a/ts-closure-transform/test/fixture/object-literal-elements.out.js
+++ b/ts-closure-transform/test/fixture/object-literal-elements.out.js
@@ -1,0 +1,19 @@
+let objLiteral = {
+    get content() {
+        return 10;
+    },
+    set content(value) {
+    },
+    value: function getValue() {
+        var _a;
+        var content = { value: undefined };
+        content.value = this.content;
+        content.value = (_a = function () {
+            return content.value();
+        }, _a.__closure = () => ({ content }), _a);
+        return content.value();
+    },
+    getValue() {
+        return this.content;
+    }
+};

--- a/ts-closure-transform/test/fixture/object-literal-elements.ts
+++ b/ts-closure-transform/test/fixture/object-literal-elements.ts
@@ -1,0 +1,17 @@
+let objLiteral = {
+    get content() {
+        return 10;
+    },
+    set content(value) {
+    },
+    value: function getValue() {
+        var content = this.content;
+        content = function() {
+            return content();
+        };
+        return content();
+    },
+    getValue() {
+        return this.content;
+    }
+};

--- a/ts-closure-transform/test/fixture/post-def.out.js
+++ b/ts-closure-transform/test/fixture/post-def.out.js
@@ -1,0 +1,6 @@
+function update() {
+    ++i.value;
+}
+update.__closure = () => ({ i });
+var i = { value: undefined };
+i.value = 0;

--- a/ts-closure-transform/test/fixture/post-def.ts
+++ b/ts-closure-transform/test/fixture/post-def.ts
@@ -1,0 +1,4 @@
+function update() {
+    i++;
+}
+var i = 0;

--- a/ts-closure-transform/test/fixture/try-statement.out.js
+++ b/ts-closure-transform/test/fixture/try-statement.out.js
@@ -1,0 +1,12 @@
+var _a;
+let e = { value: undefined };
+e.value = 10;
+let f = (_a = function () {
+    ++e.value;
+    return e.value;
+}, _a.__closure = () => ({ e }), _a);
+try {
+}
+catch (e) {
+    console.log(e);
+}

--- a/ts-closure-transform/test/fixture/try-statement.ts
+++ b/ts-closure-transform/test/fixture/try-statement.ts
@@ -1,0 +1,10 @@
+let e = 10;
+let f = function() {
+    e++;
+    return e;
+}
+try {
+
+} catch (e) {
+    console.log(e);
+}

--- a/ts-closure-transform/test/fixture/var-scope.out.js
+++ b/ts-closure-transform/test/fixture/var-scope.out.js
@@ -1,0 +1,12 @@
+function f() {
+    do {
+        var x = { value: undefined };
+        x.value = 10;
+    } while (false);
+    function g() {
+        ++x.value;
+        return x.value;
+    }
+    g.__closure = () => ({ x });
+    return g();
+}

--- a/ts-closure-transform/test/fixture/var-scope.ts
+++ b/ts-closure-transform/test/fixture/var-scope.ts
@@ -1,0 +1,10 @@
+function f() {
+    do {
+        var x = 10;
+    } while (false);
+    function g() {
+        x++;
+        return x;
+    }
+    return g();
+}

--- a/ts-closure-transform/test/index.test.ts
+++ b/ts-closure-transform/test/index.test.ts
@@ -59,7 +59,8 @@ function assertCompilesTo(sourceFile: string, expectedOutput: string) {
   compile(
     resolve(__dirname, `fixture/${sourceFile}`),
     { ...CJS_CONFIG, target: ts.ScriptTarget.Latest },
-    writeFileCallback);
+    writeFileCallback,
+    false);
 }
 
 /**
@@ -103,7 +104,7 @@ describe('Compilation', () => {
 
 describe('Serialization', () => {
   for (let fileName of getFilesWithExtension('serialization', 'ts')) {
-    compile(resolve(__dirname, `serialization/${fileName}`));
+    compile(resolve(__dirname, `serialization/${fileName}`), undefined, undefined, false);
 
     let jsFileName = resolve(__dirname, `serialization/${fileName.substr(0, fileName.length - 3)}.js`);
     let compiledModule = require(jsFileName);

--- a/ts-closure-transform/test/serialization/with.ts
+++ b/ts-closure-transform/test/serialization/with.ts
@@ -1,0 +1,57 @@
+
+import { expect } from 'chai';
+import { serialize, deserialize } from '../../../serialize-closures/src';
+
+function roundtrip<T>(value: T): T {
+  return deserialize(serialize(value));
+}
+
+export function roundTripBasicWith() {
+  let env = { counter: 10 };
+
+  let f;
+  with (env) {
+    f = () => {
+      return ++counter;
+    };
+  }
+
+  let out = roundtrip(f);
+  expect(out()).to.equal(11);
+  expect(out()).to.equal(12);
+}
+
+// If uncommented, the assertions below will fail because FlashFreeze assumes
+// that all unqualified names refer to variables, an assumption that is invalidated
+// by this particular use of the 'with' statement. This is unfortunate, but
+// 'with' is deprecated anyway.
+/*
+class Counter
+{
+  private c: number;
+
+  constructor()
+  {
+    this.c = 0;
+  }
+
+  get currentCount(): number {
+    return this.c++;
+  }
+}
+
+export function roundTripPropertyWith() {
+  let env = new Counter();
+
+  let f;
+  with (env) {
+    f = () => {
+      return currentCount;
+    };
+  }
+
+  let out = roundtrip(f);
+  expect(out()).to.equal(0);
+  expect(out()).to.equal(1);
+}
+*/


### PR DESCRIPTION
Hi! This PR makes a number of changes to the instrumentation tool based on bugs I encountered when instrumenting the Octane benchmark suite.

My changes can be binned into three major categories:
  1. Support for more JavaScript syntax, including `try` and `for` statements that declare mutated captured variables.
  2. Better support for the minutiae of JavaScript syntax, such as the function-wide reach of `var` statements.
  3. Additional instrumentation tests.

 If you intend on merging #1, then you might want to merge that one first as it will test the changes in this PR on a variety of Node versions.