### PR TITLE
Octane benchmark comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 
 # Ignore package-lock.json file.
 package-lock.json
+
+# Ignore benchmark results.
+transform-benchmarker/results

--- a/transform-benchmarker/package.json
+++ b/transform-benchmarker/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@xstream/transform-benchmarker",
+  "version": "0.1.1",
+  "description": "A benchmarking utility that runs the Octane benchmarks with the closure transform enabled.",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "scripts": {
+    "prepublish": "tsc",
+    "benchmark": "tsc && node dist/transform-benchmarker/src/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://gitlabe1.ext.net.nokia.com/vandercr/ts-serialize-closures.git"
+  },
+  "keywords": [
+    "typescript",
+    "transform",
+    "modules"
+  ],
+  "author": "Jonathan Van der Cruysse",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://gitlabe1.ext.net.nokia.com/vandercr/ts-serialize-closures/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://gitlabe1.ext.net.nokia.com/vandercr/ts-serialize-closures#readme",
+  "devDependencies": {
+    "@types/node": "^12.0.2",
+    "benchmark-octane": "^1.0.0",
+    "fs-extra": "^3.0.0",
+    "glob": "^7.1.1",
+    "things-js": "^2.0.0",
+    "ts-node": "^3.0.2",
+    "typescript": "^2.7.0-rc"
+  },
+  "dependencies": {}
+}

--- a/transform-benchmarker/package.json
+++ b/transform-benchmarker/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "@xstream/transform-benchmarker",
+  "name": "transform-benchmarker",
   "version": "0.1.1",
   "description": "A benchmarking utility that runs the Octane benchmarks with the closure transform enabled.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "private": true,
   "scripts": {
     "prepublish": "tsc",
     "original": "tsc && node dist/transform-benchmarker/src/index.js original",
@@ -13,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://gitlabe1.ext.net.nokia.com/vandercr/ts-serialize-closures.git"
+    "url": "git+https://github.com/nokia/ts-serialize-closures.git"
   },
   "keywords": [
     "typescript",
@@ -23,12 +24,12 @@
   "author": "Jonathan Van der Cruysse",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://gitlabe1.ext.net.nokia.com/vandercr/ts-serialize-closures/issues"
+    "url": "https://github.com/nokia/ts-serialize-closures/issues"
   },
   "files": [
     "dist"
   ],
-  "homepage": "https://gitlabe1.ext.net.nokia.com/vandercr/ts-serialize-closures#readme",
+  "homepage": "https://github.com/nokia/ts-serialize-closures/blob/master/README.md",
   "devDependencies": {
     "@types/node": "^12.0.2",
     "benchmark-octane": "^1.0.0",

--- a/transform-benchmarker/package.json
+++ b/transform-benchmarker/package.json
@@ -6,7 +6,9 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "prepublish": "tsc",
-    "benchmark": "tsc && node dist/transform-benchmarker/src/index.js"
+    "original": "tsc && node dist/transform-benchmarker/src/index.js original",
+    "flash-freeze": "tsc && node dist/transform-benchmarker/src/index.js flash-freeze",
+    "things-js": "tsc && node dist/transform-benchmarker/src/index.js things-js"
   },
   "repository": {
     "type": "git",

--- a/transform-benchmarker/package.json
+++ b/transform-benchmarker/package.json
@@ -21,7 +21,7 @@
     "modules"
   ],
   "author": "Jonathan Van der Cruysse",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://gitlabe1.ext.net.nokia.com/vandercr/ts-serialize-closures/issues"
   },

--- a/transform-benchmarker/package.json
+++ b/transform-benchmarker/package.json
@@ -8,7 +8,8 @@
     "prepublish": "tsc",
     "original": "tsc && node dist/transform-benchmarker/src/index.js original",
     "flash-freeze": "tsc && node dist/transform-benchmarker/src/index.js flash-freeze",
-    "things-js": "tsc && node dist/transform-benchmarker/src/index.js things-js"
+    "things-js": "tsc && node dist/transform-benchmarker/src/index.js things-js",
+    "disclosure": "tsc && node dist/transform-benchmarker/src/index.js disclosure"
   },
   "repository": {
     "type": "git",
@@ -37,5 +38,8 @@
     "ts-node": "^3.0.2",
     "typescript": "^2.7.0-rc"
   },
-  "dependencies": {}
+  "dependencies": {
+    "sync-request": "^6.1.0",
+    "then-request": "^6.0.2"
+  }
 }

--- a/transform-benchmarker/process_results.py
+++ b/transform-benchmarker/process_results.py
@@ -82,10 +82,12 @@ print(
         'results/scores.csv',
         aggregate_category('results/original-scores.csv',
                            'results/flash-freeze-scores.csv',
-                           'results/things-js-scores.csv'),
+                           'results/things-js-scores.csv',
+                           'results/disclosure-scores.csv'),
         'original',
         'flash-freeze',
-        'things-js'))
+        'things-js',
+        'disclosure'))
 
 print('Size means:')
 print(
@@ -93,10 +95,12 @@ print(
         'results/sizes.csv',
         aggregate_category('results/original-sizes.csv',
                            'results/flash-freeze-sizes.csv',
-                           'results/things-js-sizes.csv'),
+                           'results/things-js-sizes.csv',
+                           'results/disclosure-sizes.csv'),
         'original',
         'flash-freeze',
-        'things-js'))
+        'things-js',
+        'disclosure'))
 
 print('Score coordinates:')
 print(','.join(sorted(read_results('results/original-scores.csv'))))

--- a/transform-benchmarker/process_results.py
+++ b/transform-benchmarker/process_results.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# This script loads Octane scores and file sizes from the results/
+# folder and aggregates them into two CSVs: one representing score-
+# related measurements and another representing size-related measurements.
+
+import csv
+from itertools import islice
+
+
+def read_results(file_name):
+    """Reads a CSV file containing results. Produces a mapping of benchmark
+       names to numerical results."""
+    results = {}
+    with open(file_name, 'r') as csvfile:
+        spamreader = csv.reader(csvfile, delimiter=',', quotechar='|')
+        for row in islice(spamreader, 1, None):
+            results[row[0]] = float(row[1])
+    return results
+
+
+def aggregate_results(baseline, *others):
+    """Aggregates results. Takes a baseline and a number of other measurements,
+       divides all measurements by the baseline on a per-benchmark basis."""
+
+    def aggregate_benchmark(key, results):
+        if key in results:
+            return results[key] / baseline[key]
+        else:
+            return 0.0
+
+    results = []
+    for key in sorted(baseline.keys()):
+        results.append((key, 1.0) + tuple(aggregate_benchmark(key, xs)
+                                          for xs in others))
+    return results
+
+
+def aggregate_category(baseline_file, *other_files):
+    """Aggregates result files for a particular category of benchmarks."""
+    baseline = read_results(baseline_file)
+    others = [read_results(name) for name in other_files]
+    return aggregate_results(baseline, *others)
+
+
+def write_aggregated(destination, aggregated, *names):
+    """Writes aggregated results back to a CSV file."""
+    with open(destination, 'w') as csvfile:
+        fieldnames = ['benchmark'] + list(names)
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+
+        writer.writeheader()
+        for row in aggregated:
+            writer.writerow(
+                {key: value for key, value in zip(fieldnames, row)})
+
+    # We'll return a dictionary that maps names to their mean scores
+    # relative to the baseline.
+    results = {key: 0.0 for key in names}
+    count = 0
+    for row in aggregated:
+        if 0.0 in row[1:]:
+            # This benchmark errored for at least one instrumentation
+            # technique. We'll drop it entirely in the interest of fairness.
+            continue
+
+        for key, value in zip(names, row[1:]):
+            results[key] += value
+
+        count += 1
+
+    for key in names:
+        results[key] /= count
+
+    return results
+
+print("Score means:")
+print(
+    write_aggregated(
+        'results/scores.csv',
+        aggregate_category('results/original-scores.csv',
+                           'results/flash-freeze-scores.csv',
+                           'results/things-js-scores.csv'),
+        'original',
+        'flash-freeze',
+        'things-js'))
+
+print("Size means:")
+print(
+    write_aggregated(
+        'results/sizes.csv',
+        aggregate_category('results/original-sizes.csv',
+                           'results/flash-freeze-sizes.csv',
+                           'results/things-js-sizes.csv'),
+        'original',
+        'flash-freeze',
+        'things-js'))

--- a/transform-benchmarker/process_results.py
+++ b/transform-benchmarker/process_results.py
@@ -5,6 +5,7 @@
 # related measurements and another representing size-related measurements.
 
 import csv
+import math
 from itertools import islice
 
 
@@ -24,10 +25,10 @@ def aggregate_results(baseline, *others):
        divides all measurements by the baseline on a per-benchmark basis."""
 
     def aggregate_benchmark(key, results):
-        if key in results:
+        if key in results and results[key] != 0.0:
             return results[key] / baseline[key]
         else:
-            return 0.0
+            return float('nan')
 
     results = []
     for key in sorted(baseline.keys()):
@@ -59,7 +60,7 @@ def write_aggregated(destination, aggregated, *names):
     results = {key: 0.0 for key in names}
     count = 0
     for row in aggregated:
-        if 0.0 in row[1:]:
+        if any(filter(math.isnan, row[1:])):
             # This benchmark errored for at least one instrumentation
             # technique. We'll drop it entirely in the interest of fairness.
             continue
@@ -74,7 +75,8 @@ def write_aggregated(destination, aggregated, *names):
 
     return results
 
-print("Score means:")
+
+print('Score means:')
 print(
     write_aggregated(
         'results/scores.csv',
@@ -85,7 +87,7 @@ print(
         'flash-freeze',
         'things-js'))
 
-print("Size means:")
+print('Size means:')
 print(
     write_aggregated(
         'results/sizes.csv',
@@ -95,3 +97,9 @@ print(
         'original',
         'flash-freeze',
         'things-js'))
+
+print('Score coordinates:')
+print(','.join(sorted(read_results('results/original-scores.csv'))))
+
+print('Size coordinates:')
+print(','.join(sorted(read_results('results/original-sizes.csv'))))

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -107,7 +107,7 @@ function compileTo(inputFile: string, outputFile: string, transformClosures: boo
   // Then feed it to the TypeScript compiler.
   compile(
     tsCopyPath,
-    { ...CJS_CONFIG, outFile: outputFile, removeComments: true },
+    { ...CJS_CONFIG, removeComments: true },
     writeFileCallback,
     false,
     transformClosures);
@@ -154,4 +154,5 @@ let thingsJS = instrumentOctane("things-js", (from, to) => {
 });
 
 thingsJS();
+
 process.exit(0);

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -1,36 +1,46 @@
-import compile from '../../ts-closure-transform/compile';
+import compile, { CJS_CONFIG } from '../../ts-closure-transform/compile';
 import { resolve, dirname, join, sep, isAbsolute } from 'path';
-import { statSync, readdirSync, copyFileSync, fstat, mkdirSync } from 'fs';
+import { statSync, readdirSync, copyFileSync, fstat, mkdirSync, writeFileSync } from 'fs';
 
 // Recursive directory creation logic. Based on Mahmoud Mouneer's answer to
 // https://stackoverflow.com/questions/31645738/how-to-create-full-path-with-nodes-fs-mkdirsync
 function mkDirByPathSync(targetDir, { isRelativeToScript = false } = {}) {
-    const initDir = isAbsolute(targetDir) ? sep : '';
-    const baseDir = isRelativeToScript ? __dirname : '.';
-  
-    return targetDir.split(sep).reduce((parentDir, childDir) => {
-      const curDir = resolve(baseDir, parentDir, childDir);
-      try {
-        mkdirSync(curDir);
-      } catch (err) {
-        if (err.code === 'EEXIST') { // curDir already exists!
-          return curDir;
-        }
-  
-        // To avoid `EISDIR` error on Mac and `EACCES`-->`ENOENT` and `EPERM` on Windows.
-        if (err.code === 'ENOENT') { // Throw the original parentDir error on curDir `ENOENT` failure.
-          throw new Error(`EACCES: permission denied, mkdir '${parentDir}'`);
-        }
-  
-        const caughtErr = ['EACCES', 'EPERM', 'EISDIR'].indexOf(err.code) > -1;
-        if (!caughtErr || caughtErr && curDir === resolve(targetDir)) {
-          throw err; // Throw if it's just the last created dir.
-        }
+  const initDir = isAbsolute(targetDir) ? sep : '';
+  const baseDir = isRelativeToScript ? __dirname : '.';
+
+  return targetDir.split(sep).reduce((parentDir, childDir) => {
+    const curDir = resolve(baseDir, parentDir, childDir);
+    try {
+      mkdirSync(curDir);
+    } catch (err) {
+      if (err.code === 'EEXIST') { // curDir already exists!
+        return curDir;
       }
-  
-      return curDir;
-    }, initDir);
-  }
+
+      // To avoid `EISDIR` error on Mac and `EACCES`-->`ENOENT` and `EPERM` on Windows.
+      if (err.code === 'ENOENT') { // Throw the original parentDir error on curDir `ENOENT` failure.
+        throw new Error(`EACCES: permission denied, mkdir '${parentDir}'`);
+      }
+
+      const caughtErr = ['EACCES', 'EPERM', 'EISDIR'].indexOf(err.code) > -1;
+      if (!caughtErr || caughtErr && curDir === resolve(targetDir)) {
+        throw err; // Throw if it's just the last created dir.
+      }
+    }
+
+    return curDir;
+  }, initDir);
+}
+
+// Polyfill so we can still target old JS versions.
+function endsWith(value: string, suffix: string) {
+  return value.indexOf(suffix, value.length - suffix.length) !== -1;
+}
+
+// A flag that allows us to exclude the Mandreel benchmark from the
+// instrumentation pipeline. Doing so is useful for development because
+// Mandreel is a hefty benchmark that takes a long time to process.
+const includeMandreel = false;
 
 /**
  * Creates an instrumented version of the Octane benchmark suite.
@@ -38,45 +48,110 @@ function mkDirByPathSync(targetDir, { isRelativeToScript = false } = {}) {
  * @param instrumentFile A function that instruments a file and writes the result to an output file.
  * @returns A function that runs the instrumented version of the Octane benchmark suite.
  */
-function instrument_octane(
-    configuration: string,
-    instrumentFile: (inputPath: string, outputPath: string) => void):
-    () => void {
+function instrumentOctane(
+  configuration: string,
+  instrumentFile: (inputPath: string, outputPath: string) => void):
+  () => void {
 
-    let sourceRootDir = dirname(require.resolve('benchmark-octane/lib/octane'));
-    let destRootDir = resolve(__dirname, `benchmark-octane/${configuration}`);
+  let sourceRootDir = dirname(require.resolve('benchmark-octane/lib/octane'));
+  let destRootDir = resolve(__dirname, `benchmark-octane/${configuration}`);
 
-    function walk(relativePath: string) {
-        let sourcePath = resolve(sourceRootDir, relativePath);
-        let destPath = resolve(destRootDir, relativePath);
-        mkDirByPathSync(destPath);
+  function walk(relativePath: string, ignoreSource: boolean = false) {
+    let sourcePath = resolve(sourceRootDir, relativePath);
+    let destPath = resolve(destRootDir, relativePath);
+    mkDirByPathSync(destPath);
 
-        for (let name of readdirSync(sourcePath)) {
-            let f = statSync(resolve(sourcePath, name));
-            if (f.isDirectory()) {
-                // Recursively visit directories.
-                walk(join(relativePath, name));
-            } else if (name.length >= '.js'.length && name.substring(name.length - '.js'.length) == '.js') {
-                // Instrument JavaScript files.
-                instrumentFile(
-                    resolve(sourcePath, name),
-                    resolve(destPath, name));
-            } else {
-                // Copy all other files.
-                copyFileSync(
-                    resolve(sourcePath, name),
-                    resolve(destPath, name));
-            }
-        }
+    for (let name of readdirSync(sourcePath)) {
+      let f = statSync(resolve(sourcePath, name));
+      if (f.isDirectory()) {
+        // Recursively visit directories. Do not instrument the files
+        // in the JS directory because they appear to trigger a bug in
+        // the TypeScript compiler's handling of JSDoc tags. These files
+        // aren't part of the benchmark code, so excluding them is harmless.
+        walk(join(relativePath, name), ignoreSource || name == 'js');
+      } else if (!ignoreSource
+          && endsWith(name, '.js')
+          && (includeMandreel || name != 'mandreel.js')) {
+        // Instrument JavaScript files.
+        instrumentFile(
+          resolve(sourcePath, name),
+          resolve(destPath, name));
+      } else {
+        // Copy all other files.
+        copyFileSync(
+          resolve(sourcePath, name),
+          resolve(destPath, name));
+      }
     }
+  }
 
-    walk('.');
+  walk('.');
 
-    return require(resolve(destRootDir, 'octane.js')).run;
+  return require(resolve(destRootDir, 'octane.js')).run;
 }
 
-let original = instrument_octane("original", (from, to) => {
-    copyFileSync(from, to);
+function compileTo(inputFile: string, outputFile: string, transformClosures: boolean) {
+  function writeFileCallback(
+    fileName: string,
+    data: string,
+    writeByteOrderMark: boolean,
+    onError: (message: string) => void | undefined,
+    sourceFiles): void {
+
+    writeFileSync(outputFile, data, { encoding: 'utf8' });
+  }
+
+  // Copy the file to a temporary path with a 'ts' suffix.
+  let tsCopyPath = outputFile.substring(0, outputFile.length - '.js'.length) + '.ts';
+  copyFileSync(inputFile, tsCopyPath);
+  // Then feed it to the TypeScript compiler.
+  compile(
+    tsCopyPath,
+    { ...CJS_CONFIG, outFile: outputFile, removeComments: true },
+    writeFileCallback,
+    false,
+    transformClosures);
+}
+
+let original = instrumentOctane("original", (from, to) => {
+  compileTo(from, to, false);
 });
 
 original();
+
+let flashFreeze = instrumentOctane("flash-freeze", (from, to) => {
+  compileTo(from, to, true);
+});
+
+flashFreeze();
+
+let thingsJS = instrumentOctane("things-js", (from, to) => {
+  if (endsWith(from, 'base.js')) {
+    // Just copy 'base.js'. Instrumenting it will produce a stack overflow
+    // because an instrumented base.js will create ThingsJS stack frames in
+    // its reimplementation of Math.random. ThingsJS stack frame creation
+    // depends on Math.random, hence the stack overflow.
+    copyFileSync(from, to);
+    return;
+  }
+
+  let code: string = require("child_process").spawnSync("things-js", ["inst", from], { encoding: 'utf8' }).stdout;
+  // ThingsJS generates code that calls 'require' at the top of the file but then
+  // demands that 'require' is called as a property of the big sigma global.
+  // This breaks the Octane benchmark, which depends on file inclusion. We will
+  // work around this problem by patching the test runner and the tests.
+  let remove = "require('things-js/lib/core/Code').bootstrap(module, function (Σ) {";
+  if (endsWith(from, 'octane.js')) {
+    let add = "__Σ = (typeof Σ === 'undefined') ? require('things-js/lib/core/Code') : { bootstrap: function(arg1, arg2) { return arg2(Σ); } };\n" +
+      "__Σ.bootstrap(module, function (Σ) { global.Σ = Σ; ";
+    code = add + code.substr(remove.length);
+  } else {
+    let epilogueIndex = code.lastIndexOf("'mqtt://localhost'");
+    let epilogueStartIndex = code.lastIndexOf('\n', epilogueIndex);
+    code = code.substr(0, epilogueStartIndex).substr(remove.length);
+  }
+  writeFileSync(to, code, { encoding: 'utf8' });
+});
+
+thingsJS();
+process.exit(0);

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -87,7 +87,22 @@ function instrumentOctane(
 
   walk('.');
 
-  return require(resolve(destRootDir, 'octane.js')).run;
+  let suite = require(resolve(destRootDir, 'octane.js')).BenchmarkSuite;
+  function run() {
+    suite.RunSuites({
+      NotifyResult: (name, result) => {
+        console.log((name + '                      ').substr(0, 20) + ': ' + result);
+      },
+      NotifyError: (name, error) => {
+        console.log((name + '                      ').substr(0, 20) + ': ' + error);
+      },
+      NotifyScore: (score) => {
+        console.log('Score (version ' + suite.version + '): ' + score);
+      }
+    });
+  }
+
+  return run;
 }
 
 /**

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -1,0 +1,82 @@
+import compile from '../../ts-closure-transform/compile';
+import { resolve, dirname, join, sep, isAbsolute } from 'path';
+import { statSync, readdirSync, copyFileSync, fstat, mkdirSync } from 'fs';
+
+// Recursive directory creation logic. Based on Mahmoud Mouneer's answer to
+// https://stackoverflow.com/questions/31645738/how-to-create-full-path-with-nodes-fs-mkdirsync
+function mkDirByPathSync(targetDir, { isRelativeToScript = false } = {}) {
+    const initDir = isAbsolute(targetDir) ? sep : '';
+    const baseDir = isRelativeToScript ? __dirname : '.';
+  
+    return targetDir.split(sep).reduce((parentDir, childDir) => {
+      const curDir = resolve(baseDir, parentDir, childDir);
+      try {
+        mkdirSync(curDir);
+      } catch (err) {
+        if (err.code === 'EEXIST') { // curDir already exists!
+          return curDir;
+        }
+  
+        // To avoid `EISDIR` error on Mac and `EACCES`-->`ENOENT` and `EPERM` on Windows.
+        if (err.code === 'ENOENT') { // Throw the original parentDir error on curDir `ENOENT` failure.
+          throw new Error(`EACCES: permission denied, mkdir '${parentDir}'`);
+        }
+  
+        const caughtErr = ['EACCES', 'EPERM', 'EISDIR'].indexOf(err.code) > -1;
+        if (!caughtErr || caughtErr && curDir === resolve(targetDir)) {
+          throw err; // Throw if it's just the last created dir.
+        }
+      }
+  
+      return curDir;
+    }, initDir);
+  }
+
+/**
+ * Creates an instrumented version of the Octane benchmark suite.
+ * @param configuration The name of the instrumentation tool that is used.
+ * @param instrumentFile A function that instruments a file and writes the result to an output file.
+ * @returns A function that runs the instrumented version of the Octane benchmark suite.
+ */
+function instrument_octane(
+    configuration: string,
+    instrumentFile: (inputPath: string, outputPath: string) => void):
+    () => void {
+
+    let sourceRootDir = dirname(require.resolve('benchmark-octane/lib/octane'));
+    let destRootDir = resolve(__dirname, `benchmark-octane/${configuration}`);
+
+    function walk(relativePath: string) {
+        let sourcePath = resolve(sourceRootDir, relativePath);
+        let destPath = resolve(destRootDir, relativePath);
+        mkDirByPathSync(destPath);
+
+        for (let name of readdirSync(sourcePath)) {
+            let f = statSync(resolve(sourcePath, name));
+            if (f.isDirectory()) {
+                // Recursively visit directories.
+                walk(join(relativePath, name));
+            } else if (name.length >= '.js'.length && name.substring(name.length - '.js'.length) == '.js') {
+                // Instrument JavaScript files.
+                instrumentFile(
+                    resolve(sourcePath, name),
+                    resolve(destPath, name));
+            } else {
+                // Copy all other files.
+                copyFileSync(
+                    resolve(sourcePath, name),
+                    resolve(destPath, name));
+            }
+        }
+    }
+
+    walk('.');
+
+    return require(resolve(destRootDir, 'octane.js')).run;
+}
+
+let original = instrument_octane("original", (from, to) => {
+    copyFileSync(from, to);
+});
+
+original();

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -162,8 +162,7 @@ function instrumentWithThingsJS(inputFile: string, outputFile: string) {
   // work around this problem by patching the test runner and the tests.
   let remove = "require('things-js/lib/core/Code').bootstrap(module, function (Σ) {";
   if (endsWith(outputFile, 'octane.js')) {
-    let add = "__Σ = (typeof Σ === 'undefined') ? require('things-js/lib/core/Code') : { bootstrap: function(arg1, arg2) { return arg2(Σ); } };\n" +
-      "__Σ.bootstrap(module, function (Σ) { global.Σ = Σ; ";
+    let add = "require('things-js/lib/core/Code').bootstrap(module, function (Σ) { global.Σ = Σ; ";
     code = add + code.substr(remove.length);
     code = exportBenchmarkSuite(code);
   } else {

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -98,7 +98,7 @@ function compileTo(inputFile: string, outputFile: string, transformClosures: boo
     onError: (message: string) => void | undefined,
     sourceFiles): void {
 
-    if (fileName.indexOf('gbemu-part1') >= 0) {
+    if (transformClosures && fileName.indexOf('gbemu-part1') >= 0) {
       // The Gameboy benchmark is problematic for FlashFreeze because the Gameboy
       // benchmark shares mutable variables across files. Our transform assumes
       // that each file is a separate module, but the Gameboy benchmark breaks

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -89,9 +89,11 @@ function instrumentOctane(
 
   let suite = require(resolve(destRootDir, 'octane.js')).BenchmarkSuite;
   function run() {
+    let results = [];
     suite.RunSuites({
       NotifyResult: (name, result) => {
         console.log((name + '                      ').substr(0, 20) + ': ' + result);
+        results.push([name, result]);
       },
       NotifyError: (name, error) => {
         console.log((name + '                      ').substr(0, 20) + ': ' + error);
@@ -100,6 +102,10 @@ function instrumentOctane(
         console.log('Score (version ' + suite.version + '): ' + score);
       }
     });
+    let header = 'benchmark,result\n';
+    let csv = header + results.map(pair => pair[0] + ',' + pair[1]).join('\n');
+    let resultsFileName = resolve(process.cwd(), `${configuration}.csv`);
+    writeFileSync(resultsFileName, csv, { encoding: 'utf8' });
   }
 
   return run;

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -234,7 +234,7 @@ function downloadDisclosureInstrumented(relativePath: string, outputFile: string
   relativePath = relativePath.replace('octane/', 'octane/inst/');
   let url = prefix + relativePath;
 
-  console.log(relativePath);
+  console.log(`Downloading ${relativePath} from ${url}...`);
   if (relativePath == 'octane.js') {
     // Download octane.js and patch it.
     let body = request('GET', url).getBody('utf8');

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -79,10 +79,9 @@ function instrumentOctane(
         // Instrument JavaScript files, but only if they haven't been
         // instrumented already. Re-instrumenting files takes time that
         // we'd rather not waste.
-        if (alwaysCompile || !existsSync(destPath)) {
-          instrumentFile(
-            resolve(sourcePath, name),
-            resolve(destPath, name));
+        let destFilePath = resolve(destPath, name);
+        if (alwaysCompile || !existsSync(destFilePath)) {
+          instrumentFile(resolve(sourcePath, name), destFilePath);
         }
       } else {
         // Copy all other files.

--- a/transform-benchmarker/src/index.ts
+++ b/transform-benchmarker/src/index.ts
@@ -40,7 +40,7 @@ function endsWith(value: string, suffix: string) {
 // A flag that allows us to exclude the Mandreel benchmark from the
 // instrumentation pipeline. Doing so is useful for development because
 // Mandreel is a hefty benchmark that takes a long time to process.
-const includeMandreel = false;
+const includeMandreel = true;
 
 /**
  * Creates an instrumented version of the Octane benchmark suite.
@@ -118,7 +118,11 @@ function instrumentOctane(
     for (let fileName of readdirSync(resolve(destRootDir, 'octane'))) {
       let absPath = resolve(destRootDir, 'octane', fileName);
       let f = statSync(absPath);
-      if (!f.isDirectory() && endsWith(fileName, '.js')) {
+      if (!f.isDirectory()
+        && endsWith(fileName, '.js')
+        && !endsWith(fileName, 'base.js')
+        && !endsWith(fileName, 'run.js')) {
+
         sizes.push([
           fileName,
           Buffer.byteLength(readFileSync(absPath))

--- a/transform-benchmarker/tsconfig.json
+++ b/transform-benchmarker/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compileOnSave": true,
+    "compilerOptions": {
+        "target": "ES5",
+        "module": "commonjs",
+        "declaration": true,
+        "moduleResolution": "node",
+        "stripInternal": true,
+        "jsx": "react",
+        "outDir": "dist"
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}


### PR DESCRIPTION
This PR adds a benchmarking module to the repo that compares the serializer's performance with ThingsMigrate (aka ThingsJS) and FSM (aka Disclosure).

This is the benchmarking code I used to obtain the results for the META'19 paper. We might want to include the benchmarking module in the main repo, both as a means of measuring the serializer's overhead and so others can reproduce the paper's results.

Note that this PR depends on #2. The benchmarking code won't actually work until that PR is applied.