### PR TITLE
Make variable visitor consider implicitly exported identifiers

### DIFF
--- a/ts-closure-transform/test/index.test.ts
+++ b/ts-closure-transform/test/index.test.ts
@@ -109,7 +109,10 @@ describe('Serialization', () => {
     let jsFileName = resolve(__dirname, `serialization/${fileName.substr(0, fileName.length - 3)}.js`);
     let compiledModule = require(jsFileName);
     for (let exportedTestName in compiledModule) {
-      it(`${fileName}:${exportedTestName}`, compiledModule[exportedTestName]);
+      let exportedTest = compiledModule[exportedTestName];
+      if (exportedTest instanceof Function) {
+        it(`${fileName}:${exportedTestName}`, exportedTest);
+      }
     }
   }
 });

--- a/ts-closure-transform/test/serialization/enums.ts
+++ b/ts-closure-transform/test/serialization/enums.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { serialize, deserialize } from '../../../serialize-closures/src';
+
+function roundtrip<T>(value: T): T {
+    return deserialize(serialize(value));
+}
+
+export enum Match {
+    CONTAINS = "CONTAINS",
+    CROSSES = "CROSSES",
+    DISJOINT = "DISJOINT"
+}
+
+export function enumString() {
+    expect(roundtrip(Match.CROSSES)).to.equal("CROSSES");
+}


### PR DESCRIPTION
The TypeScript compiler has the strange habit of representing compiler-generated exported identifiers (e.g., `export.identifier`) as regular identifier nodes (e.g., `identifier`) tagged with a hidden flag causes the code generator to produce `export.identifier` at the last minute.

This PR makes the instrumentation tool take that behavior into account, fixing #4. It also adds the `export enum` test to the test suite.