### PR TITLE
Hoist functions before instrumenting

### DIFF
--- a/ts-closure-transform/src/hoist-functions.ts
+++ b/ts-closure-transform/src/hoist-functions.ts
@@ -1,0 +1,24 @@
+import * as ts from 'typescript';
+
+/**
+ * Creates a node visitor that hoists all function declarations it encounters.
+ * @param ctx A transformation context.
+ */
+export function createFunctionHoistingVisitor(ctx: ts.TransformationContext): ts.Visitor {
+  function visit(node: ts.Node): ts.VisitResult<ts.Node> {
+    if (ts.isFunctionDeclaration(node)) {
+      ctx.hoistFunctionDeclaration(ts.visitEachChild(node, visit, ctx));
+      return [];
+    } else {
+      return ts.visitEachChild(node, visit, ctx);
+    }
+  }
+
+  return visit;
+}
+
+export default function () {
+  return (ctx: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
+    return (sf: ts.SourceFile) => ts.visitNode(sf, createFunctionHoistingVisitor(ctx));
+  }
+}

--- a/ts-closure-transform/src/index.ts
+++ b/ts-closure-transform/src/index.ts
@@ -1,6 +1,7 @@
 import { default as closureTransform } from './transform';
 import { default as flattenImports } from './flatten-destructured-imports';
 import { default as boxMutableSharedVariables } from './box-mutable-captured-vars';
+import { default as hoistFunctions } from './hoist-functions';
 import * as ts from 'typescript';
 
 type Transform = (ctx: ts.TransformationContext) => ts.Transformer<ts.SourceFile>;
@@ -40,6 +41,7 @@ export function beforeTransform(): Transform {
  */
 export function afterTransform(): Transform {
   return createPipeline([
+    hoistFunctions(),
     boxMutableSharedVariables(),
     closureTransform()
   ]);

--- a/ts-closure-transform/src/transform.ts
+++ b/ts-closure-transform/src/transform.ts
@@ -402,10 +402,11 @@ function visitor(ctx: ts.TransformationContext) {
         // Now visit the individual declarations...
         let newDeclarations = [];
         for (let declaration of node.declarations) {
+          // ...making sure that we take their hoisted-ness into account.
           visitDeclaration(declaration.name, captured, isHoisted);
           newDeclarations.push(ts.visitEachChild(declaration, visitor(captured), ctx));
         }
-        // ...and update the declaration list.
+        // Finally, update the declaration list.
         return ts.updateVariableDeclarationList(node, newDeclarations);
       } else if (ts.isVariableDeclaration(node)) {
         visitDeclaration(node.name, captured, false);

--- a/ts-closure-transform/test/fixture/for-in.out.js
+++ b/ts-closure-transform/test/fixture/for-in.out.js
@@ -1,4 +1,8 @@
 var _a;
+function g() {
+    ++x.value;
+}
+g.__closure = () => ({ x });
 let x = { value: undefined };
 x.value = 10;
 let obj = { y: 42 };
@@ -9,7 +13,3 @@ let obj = { y: 42 };
         f();
     }
 }, _a.__closure = () => ({ obj, console }), _a)();
-function g() {
-    ++x.value;
-}
-g.__closure = () => ({ x });

--- a/ts-closure-transform/test/fixture/var-scope.out.js
+++ b/ts-closure-transform/test/fixture/var-scope.out.js
@@ -1,12 +1,12 @@
 function f() {
-    do {
-        var x = { value: undefined };
-        x.value = 10;
-    } while (false);
     function g() {
         ++x.value;
         return x.value;
     }
     g.__closure = () => ({ x });
+    do {
+        var x = { value: undefined };
+        x.value = 10;
+    } while (false);
     return g();
 }

--- a/ts-closure-transform/test/serialization/roundtripping.ts
+++ b/ts-closure-transform/test/serialization/roundtripping.ts
@@ -23,7 +23,7 @@ export function roundTripHoistingClosure() {
     let a = 1;
     let r = curriedAdd(x);
     function curriedAdd(x) {
-      a + x
+      return a + x
     }
     return r
   };

--- a/ts-closure-transform/test/serialization/roundtripping.ts
+++ b/ts-closure-transform/test/serialization/roundtripping.ts
@@ -18,6 +18,20 @@ export function roundTripClosure() {
   expect(roundtrip(factorial)(5)).to.equal(120);
 }
 
+export function roundTripHoistingClosure() {
+  let f = x => {
+    let a = 1;
+    let r = curriedAdd(x);
+    function curriedAdd(x) {
+      a + x
+    }
+    return r
+  };
+
+  let out = roundtrip(f);
+  expect(out(4)).to.equal(5);
+}
+
 export function roundTripNestedClosure() {
   let a = 10;
   let f = x => {

--- a/ts-closure-transform/test/serialization/roundtripping.ts
+++ b/ts-closure-transform/test/serialization/roundtripping.ts
@@ -23,12 +23,25 @@ export function roundTripHoistingClosure() {
     let a = 1;
     let r = curriedAdd(x);
     function curriedAdd(x) {
-      return a + x
+      return a + x;
     }
-    return r
+    return r;
   };
 
   let out = roundtrip(f);
+  expect(out(4)).to.equal(5);
+}
+
+export function roundTripHoistingClosure2() {
+  let f = () => {
+    let a = 1;
+    return curriedAdd;
+    function curriedAdd(x) {
+      return a + x;
+    }
+  };
+
+  let out = roundtrip(f());
   expect(out(4)).to.equal(5);
 }
 


### PR DESCRIPTION
This PR fixes bugs related to JavaScript's function hoisting (e.g., #6). It also includes the test case from #6, so you'll want to either merge that PR first or close it and merge this one right away.

JavaScript's function and variable hoisting semantics make instrumenting function declarations quite difficult. The changes in this PR make the closure synthesis transform take variable hoisting into account. The issue of function hoisting is neatly circumvented by injecting a pass that pre-hoists all functions, so JavaScript's function hoisting is effectively neutered by the time code gets to the real instrumentation passes.