### PR TITLE
Fix a bug in the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ before_install:
 
 install:
   # Install NPM packages.
-  - pushd serialize-closures; npm install; popd
-  - pushd ts-closure-transform; npm install; popd
+  - pushd serialize-closures && npm install && popd
+  - pushd ts-closure-transform && npm install && popd
 
 script:
   # Build projects.
-  - pushd serialize-closures; tsc; popd
-  - pushd ts-closure-transform; tsc; popd
+  - pushd serialize-closures && tsc && popd
+  - pushd ts-closure-transform && tsc && popd
   # Run the tests.
-  - pushd serialize-closures; npm test; popd
-  - pushd ts-closure-transform; npm test; popd
+  - pushd serialize-closures && npm test && popd
+  - pushd ts-closure-transform && npm test && popd


### PR DESCRIPTION
Travis commands now use the `&&` operator for chaining program invocations instead of `;`, as the latter overwrites exit codes. Exit codes getting overwritten has resulted in a CI false-negative for #6, which is definitely not a good thing.