### PR TITLE
Add unit test for generator support

### DIFF
--- a/ts-closure-transform/test/serialization/generator.ts
+++ b/ts-closure-transform/test/serialization/generator.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { serialize, deserialize } from '../../../serialize-closures/src';
+
+function roundtrip<T>(value: T): T {
+  return deserialize(serialize(value));
+}
+
+export function* myGenerator() {
+  yield 42;
+  yield 84;
+}
+
+export function simpleGenerator() {
+  expect(myGenerator().next()).to.equal(42);
+}
+
+export function roundtripGeneratorConstructor() {
+  expect(roundtrip(myGenerator)().next()).to.equal(42);
+}
+
+export function roundtripGeneratorInProgress() {
+  const gen = myGenerator();
+  expect(gen.next()).to.equal(42);
+  expect(roundtrip(gen).next()).to.equal(84);
+}


### PR DESCRIPTION
## Add unit test for generator support

I added, under `./test/serialization/`, a harness to test for serialization support of generators, including in-progress generators.

For brief background, generators are a ES6 and up JS/TS language feature (which polyfills to ES5 and below) utilizing the `yield` keyword:

```ts
function* myGenerator() {
  yield "I am running";
  yield "I am running again"
}

const gen = myGenerator();

gen.next(); // I am running
gen.next(); // I am running again
```

By in-progress generator, I mean an actual Generator object (as opposed to the constructor function) that has executed at least one step.